### PR TITLE
Added close to LDBSnapshot interface.

### DIFF
--- a/Classes/LDBSnapshot.h
+++ b/Classes/LDBSnapshot.h
@@ -121,4 +121,10 @@
                                andPrefix:(id)prefix
                               usingBlock:(id)block;
 
+/**
+ Close the snapshot.
+ 
+ @warning The instance cannot be used to perform any query after it has been closed.
+ */
+- (void) close;
 @end

--- a/Classes/LDBSnapshot.mm
+++ b/Classes/LDBSnapshot.mm
@@ -163,7 +163,7 @@
 }
 
 - (void) close {
-    if (_snapshot) {
+    if (_snapshot && _db && ![_db closed]) {
         [_db db]->ReleaseSnapshot(_snapshot);
         _snapshot = nil;
     }


### PR DESCRIPTION
I'm accessing Objective-LevelDB using swift. I always get an EBadAccess runtime error because when the snapshot is deallocated by the ARC, DB is already closed by  my shutdown code.  I would like to request to consider expose close in the snapshot interface so caller can have the control to close the snapshot.  Thanks!