### PR TITLE
Correct the capitalization of Xcode in README

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -149,7 +149,7 @@ need to take care of it manually.
 
 ### Testing
 
-If you want to run the tests, you will need XCode 5, as the test suite uses the new XCTest. 
+If you want to run the tests, you will need Xcode 5, as the test suite uses the new XCTest. 
 
 Clone this repository and, once in it,
 


### PR DESCRIPTION

This pull request corrects the capitalization of **Xcode** :sweat_smile:
https://developer.apple.com/xcode/

Created with [`xcode-readme`](https://github.com/dkhamsing/xcode-readme).
